### PR TITLE
Bug Fix: Create `docker context` before running `buildx`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - id: context
+      run: echo "::set-output name=tag::sha-${{ github.sha }}"
+      shell: bash
+
     # docker context must be created prior to setting up Docker Buildx
     # https://github.com/actions-runner-controller/actions-runner-controller/issues/893
     - name: Set up Docker Context for Buildx

--- a/action.yml
+++ b/action.yml
@@ -36,12 +36,18 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - id: context
-      run: echo "::set-output name=tag::sha-${{ github.sha }}"
+    # docker context must be created prior to setting up Docker Buildx
+    # https://github.com/actions-runner-controller/actions-runner-controller/issues/893
+    - name: Set up Docker Context for Buildx
       shell: bash
+      id: buildx-context
+      run: |
+        docker context create buildx-context
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
+      with:
+        endpoint: buildx-context
 
     - name: Login
       uses: docker/login-action@v2


### PR DESCRIPTION
## what
- Creates the Docker Context before attempting to run Buildx steps

## why
- There's a bug with the action, see https://github.com/actions-runner-controller/actions-runner-controller/issues/893
- To workaround, simply create the context before running buildx

## references
- Bug: https://github.com/actions-runner-controller/actions-runner-controller/issues/893