### PR TITLE
feat: Adds forwarded support for the ssh key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,9 @@ inputs:
   tags:
     description: "List of tags (supports https://github.com/docker/metadata-action#tags-input)"
     required: false
+  ssh:
+    description: "List of SSH agent socket or keys to expose to the build"
+    required: false
 outputs:
   image:
     description: "Docker image name"
@@ -115,3 +118,4 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         target: ${{ inputs.target }}
         labels: ${{ steps.meta.outputs.labels }}
+        ssh: ${{ inputs.ssh }}


### PR DESCRIPTION
## what

* The underlying docker-build-push action has support for setting ssh key context as a list.

## why
 * We would like to use that argument to setup some git pulls in our Dockerfiles.
