### PR TITLE
Add image_name parameter in case $org/$repo isn't acceptable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,6 @@ runs:
   using: "composite"
   steps:
     - name: Set image name
-      if: ${{ inputs.image_name == '' }}
       id: image_name
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: ''
   image_name:
-    description: "Image name (excluding registry). Defaults to $organization/$repository"
+    description: "Image name (excluding registry). Defaults to {{$organization/$repository}}."
     required: false
     default: ''
   login:

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
         if [ "${{ inputs.image_name }}" = "" ]; then
           echo 'image_name=${{ inputs.organization }}/${{ inputs.repository }}' >> "$GITHUB_OUTPUT"
         else
-          echo 'image_name=${{inputs.image_name}}' >> "$GITHUB_OUTPU"
+          echo 'image_name=${{inputs.image_name}}' >> "$GITHUB_OUTPUT"
         fi
     - name: Docker meta
       id: meta

--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
           echo 'image_name=${{ inputs.organization }}/${{ inputs.repository }}' >> "$GITHUB_OUTPUT"
         else
           echo 'image_name=${{inputs.image_name}}' >> "$GITHUB_OUTPU"
-        end
+        fi
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v4

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,11 @@ inputs:
     description: "Sets the target stage to build"
     required: false
     default: ''
+  image_name:
+    description: "Image name (excluding registry). Defaults to $organization/$repository"
+    required: false
+    # TODO: see if this works. If not, add a step to form this value.
+    default: ${{ inputs.organization }}/${{ inputs.repository }}
   login:
     description: 'Docker login'
     required: false
@@ -54,7 +59,7 @@ inputs:
 outputs:
   image:
     description: "Docker image name"
-    value: ${{ inputs.registry }}/${{ inputs.organization }}/${{ inputs.repository }}
+    value: ${{ inputs.registry }}/${{ inputs.image_name }}
   tag:
     description: "Docker image tag"
     value: ${{ steps.tag.outputs.output }}
@@ -68,7 +73,7 @@ runs:
       with:
         # list of Docker images to use as base name for tags
         images: |
-          ${{ inputs.registry }}/${{ inputs.organization }}/${{ inputs.repository }}
+          ${{ inputs.registry }}/${{ inputs.image_name }}
         # generate Docker tags based on the following events/attributes
         tags: |
           type=sha

--- a/action.yml
+++ b/action.yml
@@ -32,8 +32,7 @@ inputs:
   image_name:
     description: "Image name (excluding registry). Defaults to $organization/$repository"
     required: false
-    # TODO: see if this works. If not, add a step to form this value.
-    default: ${{ inputs.organization }}/${{ inputs.repository }}
+    default: ''
   login:
     description: 'Docker login'
     required: false
@@ -59,7 +58,7 @@ inputs:
 outputs:
   image:
     description: "Docker image name"
-    value: ${{ inputs.registry }}/${{ inputs.image_name }}
+    value: ${{ inputs.registry }}/${{ steps.image_name.outputs.image_name }}
   tag:
     description: "Docker image tag"
     value: ${{ steps.tag.outputs.output }}
@@ -67,13 +66,23 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Set image name
+      if: ${{ inputs.image_name == '' }}
+      id: image_name
+      shell: bash
+      run: |
+        if [ "${{ inputs.image_name }}" = "" ]; then
+          echo 'image_name=${{ inputs.organization }}/${{ inputs.repository }}' >> "$GITHUB_OUTPUT"
+        else
+          echo 'image_name=${{inputs.image_name}}' >> "$GITHUB_OUTPU"
+        end
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v4
       with:
         # list of Docker images to use as base name for tags
         images: |
-          ${{ inputs.registry }}/${{ inputs.image_name }}
+          ${{ inputs.registry }}/${{ steps.image_name.outputs.image_name }}
         # generate Docker tags based on the following events/attributes
         tags: |
           type=sha


### PR DESCRIPTION
## what
* Adds an `image_name` input that can be specified if the default `${{ inputs.organization }}/${{ inputs.repository }}` is not acceptable.

## why
- We have a use case where we build multiple targets from the same dockerfile in the same repo.
- As currently abstracted, the image name will be the same for these: `${{ inputs.organization }}/${{ inputs.repository }}`.
- We hacked around this by modifying the value of `inputs.repository` to include the build target, but this is incorrect (and `repository` is used on one other place here)
- We added a use case for which the above hack does not work -- two docker files, both using the default target.
- It would be nice to support the underlying action's `image_name` as a pass-through.

## references

- Build using the new `image_name` var: [link](https://github.com/3playmedia-dev/threeplaymedia_app3/actions/runs/3575992388/jobs/6013433116#step:8:80)
- Build using this branch without supplying `image_name`: [link](https://github.com/3playmedia-dev/threeplaymedia_app3/actions/runs/3575992388/jobs/6013494166#step:8:79)

I suspect tests are failing due to missing secrets in my fork, or something like that.