### PR TITLE
feat: Parameterized DOCKER_METADATA_PR_HEAD_SHA to allow for PR-HEAD tagging

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ inputs:
   docker-metadata-pr-head-sha:
     description: "Set to `true` to tag images with the PR HEAD SHA instead of the merge commit SHA within pull requests."
     required: false
-    default: false
+    default: "false"
 outputs:
   image:
     description: "Docker image name"

--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,10 @@ inputs:
   secret-files:
     description: "List of secret files to expose to the build (e.g., key=filename, MY_SECRET=./secret.txt)"
     required: false
+  docker-metadata-pr-head-sha:
+    description: "Set to `true` to tag images with the PR HEAD SHA instead of the merge commit SHA within pull requests."
+    required: false
+    default: false
 outputs:
   image:
     description: "Docker image name"
@@ -94,6 +98,14 @@ runs:
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v4
+      env:
+        # Annoyingly, docker computes the SHA tags independently of any checkout
+        # action. This option tells this action to use the PR HEAD SHA during a
+        # pull request. It will then use `github.event.pull_request.head.sha`
+        # instead of the merge commit (`github.sha`). This is useful for folks
+        # who want to avoid merge commits in their PRs (for hotfix workflows,
+        # tag predictability, builds on merge-conflicts, etc).
+        DOCKER_METADATA_PR_HEAD_SHA: ${{ inputs.docker-metadata-pr-head-sha }}
       with:
         # list of Docker images to use as base name for tags
         images: |
@@ -108,7 +120,7 @@ runs:
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
           type=raw,value=latest,enable={{is_default_branch}}
-          type=sha,format=long          
+          type=sha,format=long
           ${{ inputs.tags }}
         labels: |
           org.opencontainers.image.source=https://github.com/${{ inputs.organization }}/${{ inputs.repository }}
@@ -133,7 +145,7 @@ runs:
       shell: bash
       id: buildx-context
       run: |
-        docker context create buildx-context || true 
+        docker context create buildx-context || true
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
## what

- By default, Github Actions uses merge commits during PR events for checkout.
- Similarly, the `docker-metadata` action will use the PR merge commit for the docker SHA tags (referenced via the `github.sha` variable).
- This adds a parameter that allows users to configure docker metadata-action to compute the SHA tags to use `github.event.pull_request.head.sha` instead.
    - Unfortunately the metadata-action does not compute based on a checkout action of the code, so we have to tell it to use the correct event SHA explicitly with this environment variable.
- (Folks will also need to update the `checkout` action in their own workflows to use `github.event.pull_request.head.sha`)

See https://github.com/docker/metadata-action#environment-variables for documentation.

## why

- Some users (like us!) find the the default behavior of merge-commits challenging 
    - Since the merge commit contains code from the target branch, it becomes very difficult to build an image without `main` branch code in it for hotfixes (with a manual release workflow that we use)
    - Merge conflicts cause builds to not be triggered, which is annoying for large / long-running branches
    - Some find it unintuitive that the SHAs don't match the PR head
    - It is harder to reference tags in the ECR registry since the merge SHAs are more opaque
- Parameterized it as other folks may like the tradeoffs of merge commits for "closer to merge" results for testing and don't want to break other workflows.
    - [Confirmed the paramterization uses a `true` check so the default of `false` will work as expected.](https://github.com/docker/metadata-action/blob/35e9aff4f5d665b5aa8a8f2adffaf8a1b5f49cc0/src/context.ts#L62)  
