### PR TITLE
Custom Tags allowed as output

### DIFF
--- a/.github/workflows/test-docker-build-multi-platform.yml
+++ b/.github/workflows/test-docker-build-multi-platform.yml
@@ -38,7 +38,7 @@ jobs:
         run: | 
           json=$(docker buildx imagetools inspect ${{ steps.current.outputs.image }}:${{ steps.current.outputs.tag }} --raw )
           archs=$(echo $json | jq '[.manifests[] | .platform | select(.os != "unknown") | "\(.os)/\(.architecture)"] | join(",")')
-          echo "archs=$archs" >> $GITHUB_OUTPUT
+          echo "archs=$archs" >> $GITHUB_ENV
       
       - uses: nick-fields/assert-action@v1
         with:

--- a/.github/workflows/test-docker-build-multi-platform.yml
+++ b/.github/workflows/test-docker-build-multi-platform.yml
@@ -34,9 +34,12 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Inspect Image
+        id: inspect
         run: | 
-          docker buildx imagetools inspect ${{ steps.current.outputs.image }}:${{ steps.current.outputs.tag }} --raw | jq
-      
+          json=$(docker buildx imagetools inspect ${{ steps.current.outputs.image }}:${{ steps.current.outputs.tag }} --raw | jq )
+          echo "json=$json" >> $GITHUB_OUTPUT
+          archs=$(echo $json | jq '.manifests[] | .platform | select(.os != "unknown") | "\(.os)/\(.architecture)"')
+          echo "archs=$archs" >> $GITHUB_OUTPUT
       
       - uses: nick-fields/assert-action@v1
         with:
@@ -50,14 +53,14 @@ jobs:
 
       - uses: nick-fields/assert-action@v1
         with:
-          expected: 'containerimage.buildinfo/linux/amd64'
-          actual: ${{ steps.current.outputs.metadata }}
+          expected: 'linux/amd64'
+          actual: ${{ env.archs }}
           comparison: contains
 
       - uses: nick-fields/assert-action@v1
         with:
-          expected: 'containerimage.buildinfo/linux/arm64'
-          actual: ${{ steps.current.outputs.metadata }}
+          expected: 'linux/arm64'
+          actual: ${{ env.archs }}
           comparison: contains
 
   teardown:

--- a/.github/workflows/test-docker-build-multi-platform.yml
+++ b/.github/workflows/test-docker-build-multi-platform.yml
@@ -36,8 +36,7 @@ jobs:
       - name: Inspect Image
         id: inspect
         run: | 
-          json=$(docker buildx imagetools inspect ${{ steps.current.outputs.image }}:${{ steps.current.outputs.tag }} --raw | jq )
-          echo "json=$json" >> $GITHUB_OUTPUT
+          json=$(docker buildx imagetools inspect ${{ steps.current.outputs.image }}:${{ steps.current.outputs.tag }} --raw )
           archs=$(echo $json | jq '.manifests[] | .platform | select(.os != "unknown") | "\(.os)/\(.architecture)"')
           echo "archs=$archs" >> $GITHUB_OUTPUT
       

--- a/.github/workflows/test-docker-build-multi-platform.yml
+++ b/.github/workflows/test-docker-build-multi-platform.yml
@@ -33,6 +33,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           platforms: linux/amd64,linux/arm64
 
+      - name: Inspect Image
+        run: | 
+          docker image inspect ${{ steps.current.outputs.image }}
+          
+          docker buildx imagetools inspect ${{ steps.current.outputs.image }} --format "{{json .}}"
+      
       - uses: nick-fields/assert-action@v1
         with:
           expected: 'registry.hub.docker.com/cloudposse/github-action-docker-build-push'

--- a/.github/workflows/test-docker-build-multi-platform.yml
+++ b/.github/workflows/test-docker-build-multi-platform.yml
@@ -40,6 +40,7 @@ jobs:
           archs=$(echo $json | jq '[.manifests[] | .platform | select(.os != "unknown") | "\(.os)/\(.architecture)"] | join(",")')
           echo "archs=$archs" >> $GITHUB_ENV
       
+      
       - uses: nick-fields/assert-action@v1
         with:
           expected: 'registry.hub.docker.com/cloudposse/github-action-docker-build-push'

--- a/.github/workflows/test-docker-build-multi-platform.yml
+++ b/.github/workflows/test-docker-build-multi-platform.yml
@@ -37,7 +37,7 @@ jobs:
         id: inspect
         run: | 
           json=$(docker buildx imagetools inspect ${{ steps.current.outputs.image }}:${{ steps.current.outputs.tag }} --raw )
-          archs=$(echo $json | jq '.manifests[] | .platform | select(.os != "unknown") | "\(.os)/\(.architecture)"')
+          archs=$(echo $json | jq '[.manifests[] | .platform | select(.os != "unknown") | "\(.os)/\(.architecture)"] | join(",")')
           echo "archs=$archs" >> $GITHUB_OUTPUT
       
       - uses: nick-fields/assert-action@v1

--- a/.github/workflows/test-docker-build-multi-platform.yml
+++ b/.github/workflows/test-docker-build-multi-platform.yml
@@ -35,9 +35,9 @@ jobs:
 
       - name: Inspect Image
         run: | 
-          docker image inspect ${{ steps.current.outputs.image }}
+          docker image inspect ${{ steps.current.outputs.image }}:${{ steps.current.outputs.tag }}
           
-          docker buildx imagetools inspect ${{ steps.current.outputs.image }} --format "{{json .}}"
+          docker buildx imagetools inspect ${{ steps.current.outputs.image }}:${{ steps.current.outputs.tag }} --format "{{json .}}"
       
       - uses: nick-fields/assert-action@v1
         with:

--- a/.github/workflows/test-docker-build-multi-platform.yml
+++ b/.github/workflows/test-docker-build-multi-platform.yml
@@ -35,9 +35,7 @@ jobs:
 
       - name: Inspect Image
         run: | 
-          docker image inspect ${{ steps.current.outputs.image }}:${{ steps.current.outputs.tag }}
-          
-          docker buildx imagetools inspect ${{ steps.current.outputs.image }}:${{ steps.current.outputs.tag }} --format "{{json .}}"
+          docker buildx imagetools inspect ${{ steps.current.outputs.image }}:${{ steps.current.outputs.tag }} --raw | jq
       
       - uses: nick-fields/assert-action@v1
         with:

--- a/.github/workflows/test-docker-build-multi-platform.yml
+++ b/.github/workflows/test-docker-build-multi-platform.yml
@@ -37,6 +37,7 @@ jobs:
         run: | 
           docker buildx imagetools inspect ${{ steps.current.outputs.image }}:${{ steps.current.outputs.tag }} --raw | jq
       
+      
       - uses: nick-fields/assert-action@v1
         with:
           expected: 'registry.hub.docker.com/cloudposse/github-action-docker-build-push'

--- a/action.yml
+++ b/action.yml
@@ -174,7 +174,7 @@ runs:
         password: ${{ inputs.password }}
 
     - name: Build and push Docker images
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       id: docker-build-push-action
       with:
         context: ${{ inputs.workdir }}

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,10 @@ inputs:
     description: "List of cache export destinations for buildx (e.g., user/app:cache, type=local,dest=path/to/dir)"
     required: false
     default: type=gha,mode=max
+  no-cache:
+    description: "Send the --no-cache flag to the docker build process"
+    required: false
+    default: "false"
   ssh:
     description: "List of SSH agent socket or keys to expose to the build"
     required: false
@@ -175,6 +179,7 @@ runs:
         build-args: ${{ inputs.build-args }}
         cache-from: ${{ inputs.cache-from }}
         cache-to: ${{ inputs.cache-to }}
+        no-cache: ${{ inputs.no-cache }}
         tags: ${{ steps.meta.outputs.tags }}
         target: ${{ inputs.target }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/action.yml
+++ b/action.yml
@@ -124,7 +124,7 @@ runs:
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
           type=raw,value=latest,enable={{is_default_branch}}
-          type=sha,format=long
+          type=sha,format=long,priority=1001
           ${{ inputs.tags }}
         labels: |
           org.opencontainers.image.source=https://github.com/${{ inputs.organization }}/${{ inputs.repository }}
@@ -135,13 +135,16 @@ runs:
         version: 1.6
         force: 'true'
 
+    # here we set the first tag in the output as the output of this step
+    # this order is determined by the priority, we set the sha as 1001, as that is 1 above the defaults
+    # If a custom tag is added we can add a priority higher than that to set that as the output.
     - uses: edwardgeorge/jq-action@main
       id: tag
       with:
         compact: true
         raw-output: true
         input: ${{ steps.meta.outputs.json }}
-        script: '.tags | map(select(test("sha-\\w{8,}"))) | first | match("sha-\\w{8,}") | .string'
+        script: '.tags | first | .string'
 
     # docker context must be created prior to setting up Docker Buildx
     # https://github.com/actions-runner-controller/actions-runner-controller/issues/893

--- a/action.yml
+++ b/action.yml
@@ -146,7 +146,7 @@ runs:
         compact: true
         raw-output: true
         input: ${{ steps.meta.outputs.json }}
-        script: '.tags | first | .string'
+        script: '.tags | first'
 
     # docker context must be created prior to setting up Docker Buildx
     # https://github.com/actions-runner-controller/actions-runner-controller/issues/893

--- a/action.yml
+++ b/action.yml
@@ -140,13 +140,14 @@ runs:
     # this order is determined by the priority, we set the sha as 1001, as that is 1 above the defaults
     # If a custom tag is added we can add a priority higher than that to set that as the output.
     # https://github.com/docker/metadata-action#priority-attribute
+    # this formula is, of the tags, grab the first (highest priority), then split by : for the tag, grab the tag (last element)
     - uses: edwardgeorge/jq-action@main
       id: tag
       with:
         compact: true
         raw-output: true
         input: ${{ steps.meta.outputs.json }}
-        script: '.tags | first'
+        script: '.tags | ( first / ":") | .[length -1]'
 
     # docker context must be created prior to setting up Docker Buildx
     # https://github.com/actions-runner-controller/actions-runner-controller/issues/893

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,6 @@ inputs:
   provenance:
     description: "Generate provenance attestation for the build"
     required: false
-    default: "true"
   image_name:
     description: "Image name (excluding registry). Defaults to {{$organization/$repository}}."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,8 @@ inputs:
     default: 'linux/amd64'
   provenance:
     description: "Generate provenance attestation for the build"
-    required: true
+    required: false
+    default: "true"
   image_name:
     description: "Image name (excluding registry). Defaults to {{$organization/$repository}}."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -115,6 +115,7 @@ runs:
         images: |
           ${{ inputs.registry }}/${{ steps.image_name.outputs.image_name }}
         # generate Docker tags based on the following events/attributes
+        # we set sha as higher priority than the defaults, so that it is the first tag
         tags: |
           type=sha
           type=schedule
@@ -138,6 +139,7 @@ runs:
     # here we set the first tag in the output as the output of this step
     # this order is determined by the priority, we set the sha as 1001, as that is 1 above the defaults
     # If a custom tag is added we can add a priority higher than that to set that as the output.
+    # https://github.com/docker/metadata-action#priority-attribute
     - uses: edwardgeorge/jq-action@main
       id: tag
       with:

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     default: 'linux/amd64'
   provenance:
     description: "Generate provenance attestation for the build"
-    required: false
+    required: true
   image_name:
     description: "Image name (excluding registry). Defaults to {{$organization/$repository}}."
     required: false
@@ -158,10 +158,10 @@ runs:
         docker context create buildx-context || true
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       with:
         endpoint: buildx-context
 


### PR DESCRIPTION
## what
* the tags input allows us to add additional tags, but not necessarily use them in the output. this PR fixes that using the priority to sort the output.
* adds pass through no-cache option
* Fixes Tests with multi arch through `docker buildx inspect`

## why
* Custom tagging of applications

## References
* Duplicate of and closes #52 - testing GHA from non fork