### PR TITLE
feat: add support for build-contexts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   network:
     description: "Set the networking mode for the RUN instructions during build"
     required: false
+  build-contexts:
+    description: "List of additional build contexts (e.g., name=path)"
+    required: false
   buildkitd-flags:
     description: 'BuildKit daemon flags'
     default: '--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host'
@@ -183,6 +186,7 @@ runs:
         endpoint: buildx-context
         buildkitd-flags: "${{ inputs.debug == 'true' && '--debug' || '' }} ${{ inputs.buildkitd-flags }}" 
         driver-opts: ${{ inputs.driver-opts }}
+
     - name: Login
       uses: docker/login-action@v3
       if: ${{ contains(inputs.registry, '.amazonaws.com') || ( inputs.login != '' && inputs.password != '' ) }}
@@ -203,6 +207,7 @@ runs:
         push: true
         ssh: ${{ inputs.ssh }}
         build-args: ${{ inputs.build-args }}
+        build-contexts: ${{ inputs.build-contexts }}
         cache-from: ${{ inputs.cache-from }}
         cache-to: ${{ inputs.cache-to }}
         no-cache: ${{ inputs.no-cache }}


### PR DESCRIPTION
## what

* Adds support for the `build-contexts` arg

## why

* This is needed in particular circumstances; see https://docs.docker.com/reference/cli/docker/buildx/build/#build-context

## references

Confirmed on a private project:

![Screenshot 2024-09-26 at 12 49 11](https://github.com/user-attachments/assets/d729824d-3ace-4e9c-9381-63f2ff414e15)