### PR TITLE
ref: default to public ECR for binfmt and buildx

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,11 @@ inputs:
   driver-opts:
     description: 'List of additional driver-specific options. (eg. image=moby/buildkit:master)'
     required: false
+    default: image=public.ecr.aws/vend/moby/buildkit:buildx-stable-1
+  binfmt-image:
+    description: 'Binfmt image'
+    required: false
+    default: public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v7.0.0
   workdir:
     description: 'Working directory'
     required: false
@@ -180,14 +185,14 @@ runs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        image: public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v7.0.0
+        image: ${{ inputs.binfmt-image }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:
         endpoint: buildx-context
         buildkitd-flags: "${{ inputs.debug == 'true' && '--debug' || '' }} ${{ inputs.buildkitd-flags }}" 
-        driver-opts: "image=public.ecr.aws/vend/moby/buildkit:buildx-stable-1"
+        driver-opts: "${{ inputs.driver-opts }}"
 
     - name: Login
       uses: docker/login-action@v3

--- a/action.yml
+++ b/action.yml
@@ -179,6 +179,8 @@ runs:
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        image: public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v7.0.0
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/action.yml
+++ b/action.yml
@@ -187,7 +187,7 @@ runs:
       with:
         endpoint: buildx-context
         buildkitd-flags: "${{ inputs.debug == 'true' && '--debug' || '' }} ${{ inputs.buildkitd-flags }}" 
-        driver-opts: ${{ inputs.driver-opts }}
+        driver-opts: "image=public.ecr.aws/vend/moby/buildkit:buildx-stable-1"
 
     - name: Login
       uses: docker/login-action@v3


### PR DESCRIPTION
## what

- ref(qemu-setup): set to public ecr
- ref(diver-opts): hard set to public ecr
- chore(driver-opts,binfmt): update inputs for ecr defaults

## why

- Docker hub rate limits can cause issues with more active projects/workflows

