### PR TITLE
fix: create unique image tags for each test in order to avoid race conditions between tests

### DIFF
--- a/.github/workflows/test-docker-build-complex.yml
+++ b/.github/workflows/test-docker-build-complex.yml
@@ -34,6 +34,8 @@ jobs:
           build-args: |
             TEST_ARG=test_value
             SECOND_ARG=two
+          tags: |
+            type=sha,suffix=complex,priority=1002
 
       - uses: nick-fields/assert-action@v2
         with:
@@ -42,7 +44,7 @@ jobs:
 
       - uses: nick-fields/assert-action@v2
         with:
-          expected: sha-${{ github.sha }}
+          expected: sha-${{ github.sha }}-complex
           actual: ${{ steps.current.outputs.tag }}
 
   teardown:

--- a/.github/workflows/test-docker-build-complex.yml
+++ b/.github/workflows/test-docker-build-complex.yml
@@ -35,7 +35,7 @@ jobs:
             TEST_ARG=test_value
             SECOND_ARG=two
           tags: |
-            type=sha,suffix=complex,priority=1002
+            type=sha,format=long,suffix=-complex,priority=1002
 
       - uses: nick-fields/assert-action@v2
         with:

--- a/.github/workflows/test-docker-build-multi-platform.yml
+++ b/.github/workflows/test-docker-build-multi-platform.yml
@@ -33,7 +33,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           platforms: linux/amd64,linux/arm64
           tags: |
-            type=sha,suffix=multi-platform,priority=1002
+            type=sha,format=long,suffix=-multi-platform,priority=1002
 
       - name: Inspect Image
         id: inspect

--- a/.github/workflows/test-docker-build-multi-platform.yml
+++ b/.github/workflows/test-docker-build-multi-platform.yml
@@ -32,6 +32,8 @@ jobs:
           login: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           platforms: linux/amd64,linux/arm64
+          tags: |
+            type=sha,suffix=multi-platform,priority=1002
 
       - name: Inspect Image
         id: inspect
@@ -48,7 +50,7 @@ jobs:
 
       - uses: nick-fields/assert-action@v2
         with:
-          expected: sha-${{ github.sha }}
+          expected: sha-${{ github.sha }}-multi-platform
           actual: ${{ steps.current.outputs.tag }}
 
       - uses: nick-fields/assert-action@v2

--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -31,7 +31,7 @@ jobs:
           login: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           tags: |
-            type=sha,suffix=single-platform,priority=1002
+            type=sha,format=long,suffix=-single-platform,priority=1002
 
       - uses: nick-fields/assert-action@v2
         with:

--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -30,6 +30,8 @@ jobs:
           registry: registry.hub.docker.com
           login: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          tags: |
+            type=sha,suffix=single-platform,priority=1002
 
       - uses: nick-fields/assert-action@v2
         with:
@@ -38,7 +40,7 @@ jobs:
 
       - uses: nick-fields/assert-action@v2
         with:
-          expected: sha-${{ github.sha }}
+          expected: sha-${{ github.sha }}-single-platform
           actual: ${{ steps.current.outputs.tag }}
 
 


### PR DESCRIPTION
## what

* create unique image tags for each test in order to avoid race condititions

## why

[This assertion](https://github.com/cloudposse/github-action-docker-build-push/actions/runs/12126489107/job/33808691104#step:8:35) fails because of a race condition between the three tests in this repo.

For example, take a look at this renovate PR:

![image](https://github.com/user-attachments/assets/c3d02903-d75c-469d-b8d6-9bdbdb232a0f)

The manifest produced by each commit in the screenshot are as follows, in order from oldest to newest:

``` bash
$ docker buildx imagetools inspect registry.hub.docker.com/cloudposse/github-action-docker-build-push:sha-61a55ff023a1813dca90b5ddc2becbb248ff79b9 --raw | jq '.manifests | map(select(.platform.architecture != "unknown") | .platform.os + "/" + .platform.architecture)'
[
  "linux/amd64",
  "linux/arm64"
]
$ docker buildx imagetools inspect registry.hub.docker.com/cloudposse/github-action-docker-build-push:sha-c5f9ccf5aad31e6d255ea1631a4dc2311d88452e --raw | jq '.manifests | map(select(.platform.architecture != "unknown") | .platform.os + "/" + .platform.architecture)'
[
  "linux/amd64"
]
$ docker buildx imagetools inspect registry.hub.docker.com/cloudposse/github-action-docker-build-push:sha-fd863042e23edb3cdea14cd459f4307ed2b29f3d --raw | jq '.manifests | map(select(.platform.architecture != "unknown") | .platform.os + "/" + .platform.architecture)'
[
  "linux/amd64",
  "linux/arm64"
]
```

As previously mentioned, there is a race condition between the three tests that get dispatched by [this action](https://github.com/cloudposse/github-action-docker-build-push/blob/ee8e1e399d259d440c6345322c1fe8e1d3e6d132/.github/workflows/branch.yml#L24-L26). They all produce an image tag of `sha-[sha]`. That means that if the `test-docker-build-multi-platform.yml` build finishes _before_ the `test-docker-build.yml` build, the multi-platform manifest will be overwritten by the single-platform image.

## references

N/A
