### PR TITLE
Rollback docker/build-push-action to v5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -207,7 +207,9 @@ runs:
         password: ${{ inputs.password }}
 
     - name: Build and push Docker images
-      uses: docker/build-push-action@v6
+      # Do not update to >=v6 untill the issue would be solved
+      # https://github.com/docker/build-push-action/issues/1167
+      uses: docker/build-push-action@v5
       id: docker-build-push-action
       with:
         allow: ${{ inputs.allow }}


### PR DESCRIPTION
## what
* Rollback docker/build-push-action to v5

## why
* `docker/build-push-action@v6` is not compatible with `actions/download-artifact@v4`

## references
* https://github.com/docker/build-push-action/issues/1167
