### PR TITLE
Update Docker actions and login condition

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -200,7 +200,7 @@ runs:
 
     - name: Login
       uses: docker/login-action@v3
-      if: ${{ contains(inputs.registry, '.amazonaws.com') || ( inputs.login != '' && inputs.password != '' ) }}
+      if: ${{ inputs.login != '' && inputs.password != '' }}
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.login }}
@@ -209,7 +209,7 @@ runs:
     - name: Build and push Docker images
       # Do not update to >=v6 untill the issue would be solved
       # https://github.com/docker/build-push-action/issues/1167
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v5
       id: docker-build-push-action
       with:
         allow: ${{ inputs.allow }}


### PR DESCRIPTION
## what
* Rollback Docker action to `v5`
* Allow Docker login for ECR

## why
* The issue with Docker build and GitHub artifact API v4 is still there.
* It used to request ECR auth with AWS credentials. But we want to relax this requirement. 

## references
* https://github.com/docker/build-push-action/issues/1167