### PR TITLE
Enhance Docker image summary with structured inspect output

### DIFF
--- a/.github/workflows/test-docker-build-multi-platform.yml
+++ b/.github/workflows/test-docker-build-multi-platform.yml
@@ -40,6 +40,7 @@ jobs:
           login: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           platforms: linux/amd64,linux/arm64
+          inspect: false
           tags: |
             type=sha,format=long,suffix=-multi-platform,priority=1002
 

--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -38,7 +38,7 @@ jobs:
           registry: registry.hub.docker.com
           login: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          inspect: true
+          inspect: false
           tags: |
             type=sha,format=long,suffix=-single-platform,priority=1002
 

--- a/action.yml
+++ b/action.yml
@@ -114,7 +114,7 @@ outputs:
     value: ${{ steps.tag.outputs.output }}
   metadata:
     description: "Docker image metadata"
-    value: ${{ steps.get-metadata.outputs.metadata }}
+    value: ${{ toJSON(steps.docker-build-push-action.outputs.metadata) }}
 
 runs:
   using: "composite"
@@ -236,13 +236,8 @@ runs:
       id: get-metadata
       shell: bash
       env:
-        METADATA: ${{ toJSON(steps.docker-build-push-action.outputs.metadata) }}
+        METADATA: ${{ steps.docker-build-push-action.outputs.metadata }}
       run: |
-        {
-          echo "metadata<<EOF"
-          echo "$METADATA"
-          echo "EOF"
-        } >> $GITHUB_OUTPUT
         echo "## Docker Image Metadata" >> $GITHUB_STEP_SUMMARY
         echo '```json' >> $GITHUB_STEP_SUMMARY
         echo "$METADATA" | jq >> $GITHUB_STEP_SUMMARY

--- a/action.yml
+++ b/action.yml
@@ -219,7 +219,7 @@ runs:
       uses: docker/build-push-action@v7
       id: docker-build-push-action
       env:
-        DOCKER_BUILD_SUMMARY: {{ inputs.inspect && inputs.summary }}
+        DOCKER_BUILD_SUMMARY: ${{ inputs.inspect && inputs.summary }}
       with:
         allow: ${{ inputs.allow }}
         network: ${{ inputs.network }}

--- a/action.yml
+++ b/action.yml
@@ -243,37 +243,39 @@ runs:
         echo "metadata=$metadata" >> $GITHUB_OUTPUT
     
         # ── parse fields ────────────────────────────────────────────────────────
-        IMAGE_NAME=$(jq -r '.[0].RepoTags[0] | split(":")[1]'        inspect.json)
-        TAG=$(jq -r        '.[0].RepoTags[0] | split(":")[1]'        inspect.json)
-        DIGEST=$(jq -r     '.[0].RepoDigests[0] | split("@")[1]'     inspect.json)
-        IMAGE_ID=$(jq -r   '.[0].Id'                                  inspect.json)
+        IMAGE_NAME=$(jq -r '.[0].RepoTags[0] | split(":")[0] | split("/")[-1]' inspect.json)
+        TAG=$(jq -r        '.[0].RepoTags[0] | split(":")[1]'                  inspect.json)
+        DIGEST=$(jq -r     '.[0].RepoDigests[0] | split("@")[1]'               inspect.json)
+        IMAGE_ID=$(jq -r   '.[0].Id'                                            inspect.json)
         REVISION=$(jq -r   '.[0].Config.Labels["org.opencontainers.image.revision"] // "n/a"' inspect.json)
         SOURCE=$(jq -r     '.[0].Config.Labels["org.opencontainers.image.source"] // "n/a"'   inspect.json)
         LICENSE=$(jq -r    '.[0].Config.Labels["org.opencontainers.image.licenses"] // "n/a"' inspect.json)
-        ARCH=$(jq -r       '.[0].Architecture'                        inspect.json)
-        OS=$(jq -r         '.[0].Os'                                  inspect.json)
-        CREATED=$(jq -r    '.[0].Config.Labels["org.opencontainers.image.created"] // "n/a"'  inspect.json | cut -c1-10)
-        SIZE_BYTES=$(jq -r '.[0].Size'                                inspect.json)
+        DESCRIPTION=$(jq -r '.[0].Config.Labels["org.opencontainers.image.description"] // ""' inspect.json)
+        ARCH=$(jq -r       '.[0].Architecture'                                  inspect.json)
+        OS=$(jq -r         '.[0].Os'                                            inspect.json)
+        SIZE_BYTES=$(jq -r '.[0].Size'                                          inspect.json)
         SIZE_MB=$(echo "scale=1; $SIZE_BYTES / 1048576" | bc)
-        LAYER_COUNT=$(jq   '.[0].RootFS.Layers | length'              inspect.json)
+        LAYER_COUNT=$(jq   '.[0].RootFS.Layers | length'                        inspect.json)
         PORTS=$(jq -r      '.[0].Config.ExposedPorts // {} | keys | join(", ")' inspect.json)
-        ENTRYPOINT=$(jq -r '.[0].Config.Entrypoint | join(" ")'       inspect.json)
-        CMD=$(jq -r        '.[0].Config.Cmd | join(" ")'              inspect.json)
-        STOP_SIGNAL=$(jq -r '.[0].Config.StopSignal // "n/a"'         inspect.json)
-        DRIVER=$(jq -r     '.[0].GraphDriver.Name'                    inspect.json)
+        ENTRYPOINT=$(jq -r '.[0].Config.Entrypoint | join(" ")'                 inspect.json)
+        CMD=$(jq -r        '.[0].Config.Cmd | join(" ")'                        inspect.json)
+        STOP_SIGNAL=$(jq -r '.[0].Config.StopSignal // "n/a"'                   inspect.json)
+        DRIVER=$(jq -r     '.[0].GraphDriver.Name'                              inspect.json)
     
         # ── summary ─────────────────────────────────────────────────────────────
         {
-          echo "## 🐳 Docker image summary"
+          echo "## 🐳 ${IMAGE_NAME} &nbsp; \`${SIZE_MB} MB\`"
           echo ""
-          echo "**${IMAGE_NAME}** &nbsp; \`${LICENSE}\` &nbsp; \`${ARCH}\` &nbsp; \`${OS}\`"
+          if [[ -n "${DESCRIPTION}" ]]; then
+            echo "${DESCRIPTION}"
+            echo ""
+          fi
+          echo "\`${LICENSE}\` &nbsp; \`${ARCH}\` &nbsp; \`${OS}\`"
           echo ""
           echo "| | |"
           echo "|---|---|"
-          echo "| **Image size** | ${SIZE_MB} MB |"
           echo "| **Layers** | ${LAYER_COUNT} |"
           echo "| **Exposed ports** | \`${PORTS}\` |"
-          echo "| **Created** | ${CREATED} |"
           echo ""
           echo "---"
           echo ""
@@ -311,6 +313,17 @@ runs:
           echo "| Variable | Value |"
           echo "|---|---|"
           jq -r '.[0].Config.Env[] | split("=") | "| `\(.[0])` | `\(.[1:] | join("="))` |"' inspect.json
+          echo ""
+          echo "</details>"
+          echo ""
+    
+          # labels (collapsible)
+          echo "<details>"
+          echo "<summary>🔖 Labels</summary>"
+          echo ""
+          echo "| Label | Value |"
+          echo "|---|---|"
+          jq -r '.[0].Config.Labels // {} | to_entries[] | "| `\(.key)` | `\(.value)` |"' inspect.json
           echo ""
           echo "</details>"
           echo ""

--- a/action.yml
+++ b/action.yml
@@ -274,14 +274,12 @@ runs:
     
         # ── summary ─────────────────────────────────────────────────────────────
         {
-          echo "## 🐳 ${IMAGE_REPO}"
+          echo "## 🐳 ${IMAGE_REPO}  &nbsp; \`${SIZE_MB} MB\` &nbsp; \`${LICENSE}\` &nbsp; \`${ARCH}\` &nbsp; \`${OS}\`"
           echo ""
           if [[ -n "${DESCRIPTION}" ]]; then
             echo "${DESCRIPTION}"
             echo ""
           fi
-          echo "---"
-          echo "\`${SIZE_MB} MB\` &nbsp; \`${LICENSE}\` &nbsp; \`${ARCH}\` &nbsp; \`${OS}\`"
           echo "---"
           echo ""
     

--- a/action.yml
+++ b/action.yml
@@ -253,6 +253,7 @@ runs:
     
         # ── parse fields ────────────────────────────────────────────────────────
         IMAGE_NAME=$(jq -r '.[0].RepoTags[0] | split(":")[0] | split("/")[-1]' inspect.json)
+        IMAGE_REPO=$(jq -r '.[0].RepoTags[0] | split(":")[0]'                  inspect.json)
         TAG=$(jq -r        '.[0].RepoTags[0] | split(":")[1]'                  inspect.json)
         DIGEST=$(jq -r     '.[0].RepoDigests[0] | split("@")[1]'               inspect.json)
         IMAGE_ID=$(jq -r   '.[0].Id'                                            inspect.json)
@@ -273,12 +274,14 @@ runs:
     
         # ── summary ─────────────────────────────────────────────────────────────
         {
-          echo "## 🐳 ${IMAGE_NAME} &nbsp; \`${SIZE_MB} MB\` &nbsp; \`${LICENSE}\` &nbsp; \`${ARCH}\` &nbsp; \`${OS}\`"
+          echo "## 🐳 ${IMAGE_REPO}"
           echo ""
           if [[ -n "${DESCRIPTION}" ]]; then
             echo "${DESCRIPTION}"
             echo ""
           fi
+          echo "---"
+          echo "\`${SIZE_MB} MB\` &nbsp; \`${LICENSE}\` &nbsp; \`${ARCH}\` &nbsp; \`${OS}\`"
           echo "---"
           echo ""
     

--- a/action.yml
+++ b/action.yml
@@ -219,7 +219,7 @@ runs:
       uses: docker/build-push-action@v7
       id: docker-build-push-action
       env:
-        DOCKER_BUILD_SUMMARY: ${{ inputs.inspect && inputs.summary }}
+        DOCKER_BUILD_SUMMARY: ${{ inputs.inspect  == 'true' && inputs.summary  == 'true' }}
       with:
         allow: ${{ inputs.allow }}
         network: ${{ inputs.network }}
@@ -243,7 +243,7 @@ runs:
 
     - name: Docker Inspect
       id: inspect
-      if: ${{ inputs.summary }} == 'true'
+      if: ${{ inputs.summary == 'true' }}
       shell: bash
       run: |
         docker pull "${{ inputs.registry }}/${{ steps.image_name.outputs.image_name }}:${{ steps.tag.outputs.output }}"

--- a/action.yml
+++ b/action.yml
@@ -241,7 +241,99 @@ runs:
         docker inspect "${{ inputs.registry }}/${{ steps.image_name.outputs.image_name }}:${{ steps.tag.outputs.output }}" > inspect.json
         metadata=$(jq -c < inspect.json)
         echo "metadata=$metadata" >> $GITHUB_OUTPUT
-        echo "## Docker Image Inspect" >> $GITHUB_STEP_SUMMARY
-        echo '```json' >> $GITHUB_STEP_SUMMARY
-        cat inspect.json >> $GITHUB_STEP_SUMMARY
-        echo '```' >> $GITHUB_STEP_SUMMARY
+    
+        # ── parse fields ────────────────────────────────────────────────────────
+        IMAGE_NAME=$(jq -r '.[0].RepoTags[0] | split(":")[1]'        inspect.json)
+        TAG=$(jq -r        '.[0].RepoTags[0] | split(":")[1]'        inspect.json)
+        DIGEST=$(jq -r     '.[0].RepoDigests[0] | split("@")[1]'     inspect.json)
+        IMAGE_ID=$(jq -r   '.[0].Id'                                  inspect.json)
+        REVISION=$(jq -r   '.[0].Config.Labels["org.opencontainers.image.revision"] // "n/a"' inspect.json)
+        SOURCE=$(jq -r     '.[0].Config.Labels["org.opencontainers.image.source"] // "n/a"'   inspect.json)
+        LICENSE=$(jq -r    '.[0].Config.Labels["org.opencontainers.image.licenses"] // "n/a"' inspect.json)
+        ARCH=$(jq -r       '.[0].Architecture'                        inspect.json)
+        OS=$(jq -r         '.[0].Os'                                  inspect.json)
+        CREATED=$(jq -r    '.[0].Config.Labels["org.opencontainers.image.created"] // "n/a"'  inspect.json | cut -c1-10)
+        SIZE_BYTES=$(jq -r '.[0].Size'                                inspect.json)
+        SIZE_MB=$(echo "scale=1; $SIZE_BYTES / 1048576" | bc)
+        LAYER_COUNT=$(jq   '.[0].RootFS.Layers | length'              inspect.json)
+        PORTS=$(jq -r      '.[0].Config.ExposedPorts // {} | keys | join(", ")' inspect.json)
+        ENTRYPOINT=$(jq -r '.[0].Config.Entrypoint | join(" ")'       inspect.json)
+        CMD=$(jq -r        '.[0].Config.Cmd | join(" ")'              inspect.json)
+        STOP_SIGNAL=$(jq -r '.[0].Config.StopSignal // "n/a"'         inspect.json)
+        DRIVER=$(jq -r     '.[0].GraphDriver.Name'                    inspect.json)
+    
+        # ── summary ─────────────────────────────────────────────────────────────
+        {
+          echo "## 🐳 Docker image summary"
+          echo ""
+          echo "**${IMAGE_NAME}** &nbsp; \`${LICENSE}\` &nbsp; \`${ARCH}\` &nbsp; \`${OS}\`"
+          echo ""
+          echo "| | |"
+          echo "|---|---|"
+          echo "| **Image size** | ${SIZE_MB} MB |"
+          echo "| **Layers** | ${LAYER_COUNT} |"
+          echo "| **Exposed ports** | \`${PORTS}\` |"
+          echo "| **Created** | ${CREATED} |"
+          echo ""
+          echo "---"
+          echo ""
+    
+          # identity (always visible)
+          echo "### 🏷️ Identity"
+          echo ""
+          echo "| Field | Value |"
+          echo "|---|---|"
+          echo "| Tag | \`${TAG}\` |"
+          echo "| Digest | \`${DIGEST}\` |"
+          echo "| Image ID | \`${IMAGE_ID}\` |"
+          echo "| Revision | \`${REVISION}\` |"
+          echo "| Source | ${SOURCE} |"
+          echo ""
+    
+          # runtime (collapsible)
+          echo "<details>"
+          echo "<summary>⚙️ Runtime</summary>"
+          echo ""
+          echo "| Field | Value |"
+          echo "|---|---|"
+          echo "| Entrypoint | \`${ENTRYPOINT}\` |"
+          echo "| Command | \`${CMD}\` |"
+          echo "| Stop signal | \`${STOP_SIGNAL}\` |"
+          echo "| Storage driver | \`${DRIVER}\` |"
+          echo ""
+          echo "</details>"
+          echo ""
+    
+          # env vars (collapsible)
+          echo "<details>"
+          echo "<summary>🌱 Environment variables</summary>"
+          echo ""
+          echo "| Variable | Value |"
+          echo "|---|---|"
+          jq -r '.[0].Config.Env[] | split("=") | "| `\(.[0])` | `\(.[1:] | join("="))` |"' inspect.json
+          echo ""
+          echo "</details>"
+          echo ""
+    
+          # layers (collapsible)
+          echo "<details>"
+          echo "<summary>📦 Layers (${LAYER_COUNT})</summary>"
+          echo ""
+          echo "| # | Digest |"
+          echo "|---|---|"
+          jq -r '.[0].RootFS.Layers | to_entries[] | "| \(.key + 1) | `\(.value)` |"' inspect.json
+          echo ""
+          echo "</details>"
+          echo ""
+    
+          # raw json (collapsible)
+          echo "<details>"
+          echo "<summary>📄 Raw JSON</summary>"
+          echo ""
+          echo '```json'
+          jq '.' inspect.json
+          echo '```'
+          echo ""
+          echo "</details>"
+    
+        } >> $GITHUB_STEP_SUMMARY

--- a/action.yml
+++ b/action.yml
@@ -98,9 +98,13 @@ inputs:
     required: false
     default: "false"
   inspect:
-    description: "Set to `true` will pull and inspect the image and output it to the step summary."
+    description: "Set to `true` will pull and inspect the image and output it."
     required: false
     default: "false"
+  summary:
+    description: "Set to `true` will create step summary."
+    required: false
+    default: "true"
   debug:
     description: "Enable debug mode"
     required: false
@@ -115,6 +119,9 @@ outputs:
   metadata:
     description: "Docker image metadata"
     value: ${{ toJSON(steps.docker-build-push-action.outputs.metadata) }}
+  inspect:
+    description: "Docker image inspect metadata"
+    value: ${{ toJSON(steps.inspect.outputs.metadata) }}
 
 runs:
   using: "composite"
@@ -211,6 +218,8 @@ runs:
       # https://github.com/docker/build-push-action/issues/1167
       uses: docker/build-push-action@v7
       id: docker-build-push-action
+      env:
+        DOCKER_BUILD_SUMMARY: {{ inputs.inspect && inputs.summary }}
       with:
         allow: ${{ inputs.allow }}
         network: ${{ inputs.network }}
@@ -234,7 +243,7 @@ runs:
 
     - name: Docker Inspect
       id: inspect
-      if: ${{ inputs.inspect }} == 'true'
+      if: ${{ inputs.summary }} == 'true'
       shell: bash
       run: |
         docker pull "${{ inputs.registry }}/${{ steps.image_name.outputs.image_name }}:${{ steps.tag.outputs.output }}"
@@ -270,16 +279,9 @@ runs:
             echo "${DESCRIPTION}"
             echo ""
           fi
-          echo "| | |"
-          echo "|---|---|"
-          echo "| **Exposed ports** | \`${PORTS}\` |"
-          echo ""
           echo "---"
           echo ""
     
-          # identity (always visible)
-          echo "### 🏷️ Identity"
-          echo ""
           echo "| Field | Value |"
           echo "|---|---|"
           echo "| Tag | \`${TAG}\` |"
@@ -299,6 +301,7 @@ runs:
           echo "| Command | \`${CMD}\` |"
           echo "| Stop signal | \`${STOP_SIGNAL}\` |"
           echo "| Storage driver | \`${DRIVER}\` |"
+          echo "| Exposed ports | \`${PORTS}\` |"
           echo ""
           echo "</details>"
           echo ""

--- a/action.yml
+++ b/action.yml
@@ -232,17 +232,6 @@ runs:
         secrets: ${{ inputs.secrets }}
         secret-files: ${{ inputs.secret-files }}
 
-    - name: Get Metadata
-      id: get-metadata
-      shell: bash
-      env:
-        METADATA: ${{ steps.docker-build-push-action.outputs.metadata }}
-      run: |
-        echo "## Docker Image Metadata" >> $GITHUB_STEP_SUMMARY
-        echo '```json' >> $GITHUB_STEP_SUMMARY
-        echo "$METADATA" | jq >> $GITHUB_STEP_SUMMARY
-        echo '```' >> $GITHUB_STEP_SUMMARY
-
     - name: Docker Inspect
       id: inspect
       if: ${{ inputs.inspect }} == 'true'

--- a/action.yml
+++ b/action.yml
@@ -264,17 +264,14 @@ runs:
     
         # ── summary ─────────────────────────────────────────────────────────────
         {
-          echo "## 🐳 ${IMAGE_NAME} &nbsp; \`${SIZE_MB} MB\`"
+          echo "## 🐳 ${IMAGE_NAME} &nbsp; \`${SIZE_MB} MB\` &nbsp; \`${LICENSE}\` &nbsp; \`${ARCH}\` &nbsp; \`${OS}\`"
           echo ""
           if [[ -n "${DESCRIPTION}" ]]; then
             echo "${DESCRIPTION}"
             echo ""
           fi
-          echo "\`${LICENSE}\` &nbsp; \`${ARCH}\` &nbsp; \`${OS}\`"
-          echo ""
           echo "| | |"
           echo "|---|---|"
-          echo "| **Layers** | ${LAYER_COUNT} |"
           echo "| **Exposed ports** | \`${PORTS}\` |"
           echo ""
           echo "---"


### PR DESCRIPTION
## what
- Replace raw JSON metadata dump in step summary with a rich, structured markdown summary
- Add new `summary` input (default `true`) to control step summary generation independently from `inspect`
- Add new `inspect` output exposing the full `docker inspect` JSON
- Change `metadata` output to use `docker/build-push-action` metadata directly instead of a separate shell step
- Remove the old `Get Metadata` step entirely
- Disable `inspect` in test workflows (`test-docker-build.yml`, `test-docker-build-multi-platform.yml`)
- Control `DOCKER_BUILD_SUMMARY` env var based on `inspect` and `summary` inputs

## why
- The previous raw JSON summary was hard to read in GitHub Actions job summaries
- The new format surfaces key image details at a glance: size, architecture, OS, license, tag, digest, revision, source, runtime config, env vars, labels, and layers — each in collapsible sections
- Separating `summary` from `inspect` gives users finer control over what gets generated

## references
- https://github.com/docker/build-push-action