### PR TITLE
Bump cloudposse/github-action-jq from 0.4.0 to 0.4.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -170,7 +170,7 @@ runs:
     # If a custom tag is added we can add a priority higher than that to set that as the output.
     # https://github.com/docker/metadata-action#priority-attribute
     # this formula is, of the tags, grab the first (highest priority), then split by : for the tag, grab the tag (last element)
-    - uses: cloudposse/github-action-jq@0.4.0
+    - uses: cloudposse/github-action-jq@0.4.1
       id: tag
       with:
         compact: true

--- a/action.yml
+++ b/action.yml
@@ -170,7 +170,7 @@ runs:
     # If a custom tag is added we can add a priority higher than that to set that as the output.
     # https://github.com/docker/metadata-action#priority-attribute
     # this formula is, of the tags, grab the first (highest priority), then split by : for the tag, grab the tag (last element)
-    - uses: cloudposse/github-action-jq@0.4.1
+    - uses: cloudposse/github-action-jq@v0.4.1
       id: tag
       with:
         compact: true


### PR DESCRIPTION
## what
- Bump `cloudposse/github-action-jq` from `0.4.0` to `0.4.1`

## why
- Pick up the latest patch release with bug fixes and improvements

## references
- https://github.com/cloudposse/github-action-jq